### PR TITLE
Close date picker container if clicked elsewhere

### DIFF
--- a/jquery-daterange-picker.js
+++ b/jquery-daterange-picker.js
@@ -295,6 +295,16 @@
 
       });
 
+
+      // close date picker if clicked elsewhere
+      $(document).click(function (event) {
+        var $target = $(event.target);
+        if (!($target.attr('id') === self._$element.attr('id') ||
+          $target.closest('#daterange-picker-container, .ui-datepicker-header').length)) {
+          self._$container.hide();
+        }
+      });
+
     }
 
   });


### PR DESCRIPTION
This event handler catches all clicks and closes the date range picker when its an external click.
